### PR TITLE
Add config for setting window title.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Example config:
  - `tcp` - list of additional TCP ports to open if Open to WAN button set to UPnP
  - `udp` - list of additional UDP ports to open if Open to WAN button set to UPnP
  - `hideIps` - hide IP addresses when opening to WAN? (`true` or `false`)
+ - `setWindowTitle` - update minecraft window title to reflect online/offline status?  (`true` or `false`)

--- a/common/src/main/java/xyz/bobkinn/opentopublic/Config.java
+++ b/common/src/main/java/xyz/bobkinn/opentopublic/Config.java
@@ -10,11 +10,13 @@ public class Config {
     private final List<Integer> tcp;
     private final List<Integer> udp;
     private final boolean hideIps;
+    private final boolean setWindowTitle;
 
     public Config() {
         this.tcp = new ArrayList<>();
         this.udp = new ArrayList<>();
         this.hideIps = false;
+        this.setWindowTitle = false; //I think this should be set to false by default, there's no real need for it, but feel free to edit this..
     }
 
 }

--- a/common/src/main/java/xyz/bobkinn/opentopublic/mixin/MixinMinecraft.java
+++ b/common/src/main/java/xyz/bobkinn/opentopublic/mixin/MixinMinecraft.java
@@ -54,7 +54,9 @@ public abstract class MixinMinecraft {
 
     @Inject(method = "updateTitle", at = @At("RETURN"))
     public void onUpdateWindowTitle(CallbackInfo ci) {
-        this.window.setTitle(openToPublic$getTitle());
+        if ((OpenToPublic.cfg != null) && (OpenToPublic.cfg.isSetWindowTitle())) {
+            this.window.setTitle(openToPublic$getTitle());
+        }
     }
 
     @Unique


### PR DESCRIPTION
So by default the config is going to be false when first created, if you want it to be defaulted to true you should initiate the config before the mixin checks the value, otherwise it either won't apply or it will crash the game without the null check.

If you have another way of doing this you can deny this pull request and do it that way, I highly recommend a config for this, it actually took me an hour to figure out it was this mod overriding my modpack title; in the process of figuring it out though I found a new method of searching the code in every mod in the modpack within seconds, so that's good at least.